### PR TITLE
Move rjags to Suggests:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,11 +10,11 @@ Depends:
     R (>= 3.5)
 Imports:
     coda,
-    nlme,
-    rjags
+    nlme
 Suggests: 
     lattice, 
-    lme4
+    lme4,
+    rjags
 Description: Methods (standard and advanced) for analysis of agreement between measurement methods. These cover Bland-Altman plots, Deming regression, Lin's Total deviation index, and difference-on-average regression. See Carstensen B. (2010) "Comparing Clinical Measurement Methods: A Practical Guide (Statistics in Practice)" <doi:10.1002/9780470683019> for more information.
 License: GPL (>= 2)
 Encoding: UTF-8


### PR DESCRIPTION
It seems like most of the package functionality does not depend on rjags (only `MCmcmc()` does). 

Since JAGS is not trival to install (compared to r-packages on CRAN). I believe this creates unnecessary friction for people who just want to check if the package can help them with their analysis.

There is already a check in `MCmcmc()` that rjags or RWinBugs is installed, so I believe moving rjags to Suggests is sufficient.

