### PR TITLE
Fixing a bug in Meth()

### DIFF
--- a/R/Meth.r
+++ b/R/Meth.r
@@ -117,8 +117,8 @@ if( methods.in.y )
     repl <- match( repl, dfr.nam )
   if( is.numeric(repl) & length(repl)==1 )
     {
-    repl <- data[,repl]
     taken <- c(taken,repl.col<-repl)
+    repl <- data[,repl]
     }
   else repl <- make.repl( data.frame(meth=rep(1,Nr),item=item) )$repl
 

--- a/R/Meth.r
+++ b/R/Meth.r
@@ -108,7 +108,7 @@ if( methods.in.y )
   if( is.numeric(item) & length(item)==1 )
     {
     taken <- c(taken,item.col<-item)
-    item <- data[,item]
+    item <- data[[item]]
     }
   else item <- rows
 
@@ -118,7 +118,7 @@ if( methods.in.y )
   if( is.numeric(repl) & length(repl)==1 )
     {
     taken <- c(taken,repl.col<-repl)
-    repl <- data[,repl]
+    repl <- data[[repl]]
     }
   else repl <- make.repl( data.frame(meth=rep(1,Nr),item=item) )$repl
 

--- a/R/Meth.r
+++ b/R/Meth.r
@@ -152,7 +152,7 @@ else
   if( is.numeric(item) & length(item)==1 )
     {
     taken <- c(taken,item.col<-item)
-    item <- data[,item]
+    item <- data[[item]]
     }
   else item <- rows
   if( is.na(item)[1] ) stop( "\nitem not properly specified.")
@@ -165,7 +165,7 @@ else
   if( is.numeric(repl) & length(repl)==1 )
     {
     taken <- c(taken,repl.col<-repl)
-    repl <- data[,repl]
+    repl <- data[[repl]]
     }
   else repl <- rep(1,nrow(data))
 


### PR DESCRIPTION
I tried to run `MethComp::Meth(data, y=c('co_ref', 'co_exp'), item = 'id')`

This gave an error, because of line#123 make.repl( data.frame(meth=rep(1,Nr),item=item) )

The function expects a data.frame with a column named "item", however, when data.frame(...) is passed a data.frame (here data[,item]) it will use the names in this data.frame instead.

These changes fixed the issue and it works with `MethComp::Meth(data, y=c('co_ref', 'co_exp'), item = 'id', repl = 'time')`. 
I have not tested it with other combinations of parameters.